### PR TITLE
Format studioImpression data correctly

### DIFF
--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -9,7 +9,7 @@ type CarouselProps = {
   className?: string,
   sizes: string,
   slides: Slide[],
-  width: number,
+  width?: number,
 };
 
 const Carousel = ({ caption, className, slides, sizes, width }: CarouselProps) => {
@@ -20,7 +20,7 @@ const Carousel = ({ caption, className, slides, sizes, width }: CarouselProps) =
   if (!slides) {
     return null;
   }
-console.log(slides)
+
   return (
     <div className={`${styles.carousel} ${className}`}>
       <div className={styles.slides}>

--- a/src/pages/studio/index.tsx
+++ b/src/pages/studio/index.tsx
@@ -58,7 +58,7 @@ const Studio = ({ blurb, blocks, skillset, studioImpression, vacancies }) => (
       caption="Studio Impressions"
       className={styles.carousel}
       sizes="(max-width: 768px) 100vw, 50vw"
-      slides={studioImpression}
+      slides={studioImpression.map(content => ({ image: content }))}
     />
 
     {blocks.map(block => (


### PR DESCRIPTION
Studio impression data, unlike most other slide data, does not nest image data within an `image` property. As a result, slider is currently broken on studio page.

**Steps to test **
1.  Currently the office photo slider on the Studio page does not show any images
2. Check that the slider now displays images correctly on the Studio page