### PR TITLE
Add credits component, set up Block on DatoCMS

### DIFF
--- a/src/api/QUERIES.js
+++ b/src/api/QUERIES.js
@@ -124,6 +124,11 @@ export const SINGLE_PROJECT_QUERY = `
       intro
       title
       details
+      credits {
+        label
+        text
+        link
+      }
       ...Thumbnail
       relatedProjectsTitle
       relatedProjects {

--- a/src/components/ProjectDetail/ContentBlock/ContentBlock.module.scss
+++ b/src/components/ProjectDetail/ContentBlock/ContentBlock.module.scss
@@ -69,15 +69,16 @@
   margin: 10vw 0 5%;
   padding: 128px 22px 0;
 
-  dt, dd {
+  dt,
+  dd {
     padding-bottom: 22px;
     line-height: 1.3;
   }
 
-    dt {
-      max-width: 115px;
-      padding-right: 38px;
-    }
+  dt {
+    max-width: 115px;
+    padding-right: 38px;
+  }
 
   &.creditsAdjustedSpacing {
     margin-top: 100px;
@@ -103,7 +104,6 @@
     width: 100vw;
     justify-content: space-between;
   }
-
 }
 
 @media (min-width: 576px) {
@@ -192,10 +192,6 @@
   .credits {
     max-width: 768px;
     margin: 0 auto 8%;
-
-    &.creditsAdjustedSpacing {
-      margin-top: 120px;
-    }
   }
 }
 

--- a/src/components/ProjectDetail/Credits/Credits.module.scss
+++ b/src/components/ProjectDetail/Credits/Credits.module.scss
@@ -1,0 +1,41 @@
+.wrapper {
+  margin: 10vw 0 5%;
+  padding: 128px 22px 0;
+
+  @media (min-width: 576px) {
+    font-size: var(--font-small);
+    width: var(--width);
+    margin: 8vw 0;
+    padding: 128px 64px 0;
+    display: grid;
+    grid-template-columns: min-content 1fr;
+
+    dt {
+      white-space: nowrap;
+    }
+  }
+
+  @media (min-width: 864px) {
+    font-size: 28px;
+    max-width: 768px;
+    margin: 0 auto 8%;
+  }
+
+  @media (min-width: 1152px) {
+    max-width: 1024px;
+  }
+
+  dt,
+  dd {
+    padding-bottom: 22px;
+    line-height: 1.3;
+  }
+
+  dt {
+    max-width: 115px;
+    padding-right: 38px;
+  }
+  dd {
+    white-space: pre-line;
+  }
+}

--- a/src/components/ProjectDetail/Credits/Credits.tsx
+++ b/src/components/ProjectDetail/Credits/Credits.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { ReactMarkdown } from "react-markdown/lib/react-markdown";
+
+import { CreditsType } from "../../../types";
+
+import styles from "./Credits.module.scss";
+
+type CreditsProps = {
+  details: { [key: string]: string };
+  credits: CreditsType[];
+};
+
+export const Credits = ({ credits, details }: CreditsProps) => {
+  // Until we refactor the content on the CMS
+  if (!credits.length) {
+    return (
+      <dl aria-label="Project Details" className={styles.wrapper}>
+        {Object.entries(details ?? {})?.map(([key, value]) => (
+          <React.Fragment key={`${key}-${value}`}>
+            <dt>{`${key}:`}</dt>
+
+            <dd>
+              <ReactMarkdown linkTarget="_blank">
+                {value.replaceAll("<br />", "<br>").replaceAll("<br>", "\n\n")}
+              </ReactMarkdown>
+            </dd>
+          </React.Fragment>
+        ))}
+      </dl>
+    );
+  }
+
+  return (
+    <dl aria-label="Project Details" className={styles.wrapper}>
+      {credits.map((credit) => (
+        <React.Fragment key={credit.label}>
+          <dt>{`${credit.label}:`}</dt>
+
+          <dd>
+            {credit.link ? (
+              <a href={credit.link} target="_blank" rel="noreferrer noopener">
+                {credit.text}
+              </a>
+            ) : (
+              credit.text
+            )}
+          </dd>
+        </React.Fragment>
+      ))}
+    </dl>
+  );
+};
+
+export default Credits;

--- a/src/components/ProjectDetail/ProjectDetail.module.scss
+++ b/src/components/ProjectDetail/ProjectDetail.module.scss
@@ -62,31 +62,11 @@
     text-decoration: underline;
   }
 }
+
 .isCentered {
   text-align: center;
 }
-.credits {
-  margin: 10vw 0 5%;
-  padding: 128px 22px 0;
 
-  dt,
-  dd {
-    padding-bottom: 22px;
-    line-height: 1.3;
-  }
-
-  dt {
-    max-width: 115px;
-    padding-right: 38px;
-  }
-  dd {
-    white-space: pre-line;
-  }
-  &.creditsAdjustedSpacing {
-    margin-top: 100px;
-    padding-top: 0;
-  }
-}
 
 .carouselWrapper {
   flex: 1;
@@ -116,8 +96,7 @@
     font-size: var(--font-med);
   }
 
-  .text,
-  .credits {
+  .text {
     font-size: var(--font-small);
   }
 
@@ -139,18 +118,6 @@
     max-width: 368px;
     padding: 6px 0 0;
   }
-
-  .credits {
-    width: var(--width);
-    margin: 8vw 0;
-    padding: 128px 64px 0;
-    display: grid;
-    grid-template-columns: min-content 1fr;
-
-    :global(dt) {
-      white-space: nowrap;
-    }
-  }
 }
 
 @media (min-width: 864px) {
@@ -169,8 +136,7 @@
     font-size: var(--font-med);
   }
 
-  .text,
-  .credits {
+  .text {
     font-size: 28px;
   }
 
@@ -186,21 +152,12 @@
     margin: 8vw auto;
   }
 
-  .credits {
-    max-width: 768px;
-    margin: 0 auto 8%;
-
-    &.creditsAdjustedSpacing {
-      margin-top: 120px;
-    }
-  }
 }
 
 @media (min-width: 1152px) {
   .title,
   .intro,
-  .text,
-  .credits {
+  .text {
     max-width: 1024px;
   }
 

--- a/src/components/ProjectDetail/ProjectDetail.tsx
+++ b/src/components/ProjectDetail/ProjectDetail.tsx
@@ -4,18 +4,28 @@ import RelatedProjectSlider from './RelatedProjectSlider/RelatedProjectSlider';
 import styles from './ProjectDetail.module.scss';
 import ContentBlock from './ContentBlock/ContentBlock';
 import BackScrim from './BackScrim/BackScrim';
-import { ContentBlockType, OpenGraph, RelatedProject, VideoData } from '../../types';
+import {
+  ContentBlockType,
+  CreditsType,
+  OpenGraph,
+  RelatedProject,
+  VideoData,
+} from '../../types'
+
+import Credits from './Credits/Credits';
 
 type ProjectDetailProps = {
-  content: ContentBlockType[],
-  details: {[key:string]: string},
-  intro: string,
-  relatedProjectsTitle: string,
-  relatedProjects: RelatedProject[],
-  title: string,
-}
+  credits: CreditsType[];
+  content: ContentBlockType[];
+  details: { [key: string]: string };
+  intro: string;
+  relatedProjectsTitle: string;
+  relatedProjects: RelatedProject[];
+  title: string;
+};
 
 const ProjectDetail = ({
+  credits,
   content,
   details,
   intro,
@@ -39,19 +49,7 @@ const ProjectDetail = ({
         <ContentBlock {...block} key={block.id} />
       ))}
 
-      <dl aria-label="Project Details" className={styles.credits}>
-        {Object.entries(details ?? {})?.map(([key, value]) => (
-          <React.Fragment key={`${key}-${value}`}>
-            <dt>{`${key}:`}</dt>
-
-            <dd>
-              <ReactMarkdown linkTarget="_blank">
-                {value.replaceAll('<br />', '<br>').replaceAll('<br>', '\n\n')}
-              </ReactMarkdown>
-            </dd>
-          </React.Fragment>
-        ))}
-      </dl>
+      <Credits credits={credits} details={details} />
 
       {relatedProjects && relatedProjects.length > 0 && (
         <RelatedProjectSlider

--- a/src/pages/projects/[slug]/index.tsx
+++ b/src/pages/projects/[slug]/index.tsx
@@ -10,23 +10,30 @@ import getDataFromBackend from '../../../api/getDataFromBackend';
 import styles from './index.module.scss';
 import addAdditionalInfoToBlocks from '../../../api/addAdditionalInfoToBlocks';
 import { getVideoData } from '../../../api/videos/getVideoData.mjs';
-import { ContentBlockType, OpenGraph, RelatedProject, VideoData } from '../../../types';
+import {
+  ContentBlockType,
+  CreditsType,
+  OpenGraph,
+  RelatedProject,
+} from '../../../types';
 
 type ProjectProps = {
-  content: ContentBlockType[],
-  details: { [key: string]: string },
-  featuredImage: ImageData,
-  id: string,
-  intro: string,
-  relatedProjectsTitle: string,
-  relatedProjects: RelatedProject[],
-  opengraph: OpenGraph,
-  title: string,
-}
+  content: ContentBlockType[];
+  credits?: CreditsType[];
+  details: { [key: string]: string };
+  featuredImage: ImageData;
+  id: string;
+  intro: string;
+  relatedProjectsTitle: string;
+  relatedProjects: RelatedProject[];
+  opengraph: OpenGraph;
+  title: string;
+};
 
 const Project = ({
   content,
   details,
+  credits,
   featuredImage,
   intro,
   opengraph: { description: ogDescription, image, title: ogTitle },
@@ -47,6 +54,7 @@ const Project = ({
       <ProjectDetail
         content={content}
         details={details}
+        credits={credits}
         intro={intro}
         relatedProjects={relatedProjects}
         relatedProjectsTitle={relatedProjectsTitle}
@@ -72,10 +80,10 @@ export const getStaticProps = async ({ params, preview }) => {
       content: await addAdditionalInfoToBlocks(project.content),
       opengraph: project.opengraph ?? {},
       relatedProjects: await Promise.all(
-        project.relatedProjects?.map(async related => ({
+        project.relatedProjects?.map(async (related) => ({
           ...related,
           featuredVideo: await getVideoData(related.featuredVideo),
-        })),
+        }))
       ),
     },
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,12 @@ export type Slide = {
   video: VideoData,
 }
 
+export type CreditsType = {
+  link: string,
+  label: string,
+  text: string,
+}
+
 export const BLOCK_TYPES = {
   CarouselBlockRecord: 'CarouselBlockRecord',
   HorizontalRowRecord: 'HorizontalRowRecord',


### PR DESCRIPTION
- Add new Block on DatoCMS called Credits
- Create new component to render these Credits
- Add graphql fragment and typescript types
- Still leave the old `details` in use, so that the code is backwards compatible until we update all the projects in the CMS