### PR TITLE
Carousel Layering

### DIFF
--- a/src/components/Carousel/Carousel.module.css
+++ b/src/components/Carousel/Carousel.module.css
@@ -24,6 +24,10 @@
     width: 100%;
   }
 
+  &[data-visible="false"] {
+    pointer-events: none;
+  }
+
   &[data-visible="true"] {
     transition: opacity 1.2s;
     opacity: 1;


### PR DESCRIPTION
- disable pointer events in hidden images in carousel

## Testing
- Go on the project page
- Switch between slides on the carousels with images
- Right click -> Open image in new tap
- The opened image should always be the one you currently see on the carousel