### PR TITLE
Add support for block anchors

### DIFF
--- a/src/api/QUERIES.js
+++ b/src/api/QUERIES.js
@@ -46,6 +46,13 @@ query {
 }
 `;
 
+const sharedValues = `
+id
+anchorId
+width
+marginTop
+marginLeft`;
+
 const addBlockQuery = ({
   hasVideo = false,
   hasText = false,
@@ -58,47 +65,34 @@ ${hasVideo
           caption
           hasAudio
           hasControls
-          id
           loops
-          marginLeft
-          marginTop
           video
-          width
+          ${sharedValues}
 }
 `
     : ''
   }
 ${hasText
     ? `... on TextBlockRecord {
-  id
   text
-  width
-  marginTop
-  marginLeft
+  ${sharedValues}
 }
 `
     : ''
   }
 ${hasImage
     ? `... on ImageBlockRecord {
-  id
-  width
-  marginTop
-  marginLeft
   caption
   image {
     ...ImageDataObject
   }
+  ${sharedValues}
 }
 `
     : ''
   }
 ${hasCarousel
     ? `... on CarouselBlockRecord {
-  id
-  marginLeft
-  marginTop
-  width
   slides {
     id
     video
@@ -106,6 +100,7 @@ ${hasCarousel
       ...ImageDataObject
     }
   }
+  ${sharedValues}
 }
 `
     : ''

--- a/src/components/ProjectDetail/ContentBlock/ContentBlock.tsx
+++ b/src/components/ProjectDetail/ContentBlock/ContentBlock.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { BLOCK_TYPES, CarouselBlock, ImageBlock, TextBlock, VideoBlock } from '../../../types';
+import { BLOCK_TYPES, CarouselBlock, GenericBlockAttributes, ImageBlock, TextBlock, VideoBlock } from '../../../types';
 import Caption from '../../Caption/Caption';
 import Carousel from '../../Carousel/Carousel';
 import Image from '../../Image/Image';
@@ -10,20 +10,17 @@ import styles from './ContentBlock.module.scss';
 type ContentBlockProps = {
   __typename: string,
   blocks?: ContentBlockProps[]
-  width: number,
-  id: string,
-  marginLeft: number,
-  marginTop: number,
-}
+} & GenericBlockAttributes;
 
 const ContentBlock = ({
-    __typename,
-    blocks,
-    width,
-    id,
-    marginLeft,
-    marginTop,
-    ...blockProps
+  __typename,
+  blocks,
+  width,
+  id,
+  marginLeft,
+  marginTop,
+  anchorId,
+  ...blockProps
 }: ContentBlockProps) => {
   const renderBlock = () => {
     if (__typename === BLOCK_TYPES.ImageBlockRecord) {
@@ -78,19 +75,22 @@ const ContentBlock = ({
       )
     }
 
-    {__typename === BLOCK_TYPES.HorizontalRowRecord && blocks && (
-      <div className={styles.horizontalRow}>
-        {blocks?.map(subblock => (
-          <ContentBlock {...subblock} key={subblock.id} />
-        ))}
-      </div>
-    )}
+    {
+      __typename === BLOCK_TYPES.HorizontalRowRecord && blocks && (
+        <div className={styles.horizontalRow}>
+          {blocks?.map(subblock => (
+            <ContentBlock {...subblock} key={subblock.id} />
+          ))}
+        </div>
+      )
+    }
   };
 
   return (
     <div
       className={styles.item}
       key={id}
+      id={anchorId}
       style={{
         '--marginLeft': `${marginLeft}vw`,
         '--marginTop': `calc(${width}vw * ${marginTop / 100})`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,8 @@ export const BLOCK_TYPES = {
   VideoBlockRecord: 'VideoBlockRecord',
 } as const;
 
-type GenericBlockAttributes = {
+export type GenericBlockAttributes = {
+  anchorId: string,
   id: string,
   marginLeft: number,
   marginTop: number,


### PR DESCRIPTION
This MR adds support for linking directly to specific content blocks on a page, by appending a "#anchor" anchor ID to the end of a URL.

For example: 

https://random.studio/projects/fluid-forms-for-ecco-x-the-north-american-pavilion will go to the top of the Ecco page
https://random.studio/projects/fluid-forms-for-ecco-x-the-north-american-pavilion#store will jump to the image of a store at the bottom of the page

Anchor IDs are completely optional, but can be provided via the CMS when creating/editing a block.

**Steps to test**
1.  Using the preview link, visit the Ecco page. It will open at the top
2. Append "#store" and hit enter. The page will jump to and align to the top of the screen the photo of the store front