### PR TITLE
Add support for external website/archive URLs

### DIFF
--- a/src/api/QUERIES.js
+++ b/src/api/QUERIES.js
@@ -124,6 +124,7 @@ export const SINGLE_PROJECT_QUERY = `
       intro
       title
       details
+      externalUrl
       credits {
         label
         text

--- a/src/components/ProjectDetail/Credits/Credits.module.scss
+++ b/src/components/ProjectDetail/Credits/Credits.module.scss
@@ -39,3 +39,8 @@
     white-space: pre-line;
   }
 }
+
+.externalUrl {
+  grid-column: 1 / 3;
+  padding-top: 44px;
+}

--- a/src/components/ProjectDetail/Credits/Credits.module.scss
+++ b/src/components/ProjectDetail/Credits/Credits.module.scss
@@ -43,4 +43,21 @@
 .externalUrl {
   grid-column: 1 / 3;
   padding-top: 44px;
+  position: relative;
+  color: #737373;
+
+  @supports (width: fit-content) {
+    text-decoration: none;
+    width: fit-content;
+
+    &::after {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 1px;
+      background-color: #737373;
+      content: '';
+    }
+  }
 }

--- a/src/components/ProjectDetail/Credits/Credits.module.scss
+++ b/src/components/ProjectDetail/Credits/Credits.module.scss
@@ -44,7 +44,7 @@
   grid-column: 1 / 3;
   padding-top: 44px;
   position: relative;
-  color: #737373;
+  color: var(--dark-grey);
 
   @supports (width: fit-content) {
     text-decoration: none;
@@ -56,7 +56,7 @@
       left: 0;
       width: 100%;
       height: 1px;
-      background-color: #737373;
+      background-color: var(--dark-grey);
       content: '';
     }
   }

--- a/src/components/ProjectDetail/Credits/Credits.tsx
+++ b/src/components/ProjectDetail/Credits/Credits.tsx
@@ -6,11 +6,12 @@ import { CreditsType } from "../../../types";
 import styles from "./Credits.module.scss";
 
 type CreditsProps = {
-  details: { [key: string]: string };
   credits: CreditsType[];
+  details: { [key: string]: string };
+  externalUrl: string;
 };
 
-export const Credits = ({ credits, details }: CreditsProps) => {
+export const Credits = ({ credits, details, externalUrl }: CreditsProps) => {
   // Until we refactor the content on the CMS
   if (!credits.length) {
     return (
@@ -47,6 +48,7 @@ export const Credits = ({ credits, details }: CreditsProps) => {
           </dd>
         </React.Fragment>
       ))}
+      {externalUrl && <a className={styles.externalUrl} href={externalUrl} target="_blank" rel="noreferrer noopener">View website</a>}
     </dl>
   );
 };

--- a/src/components/ProjectDetail/ProjectDetail.tsx
+++ b/src/components/ProjectDetail/ProjectDetail.tsx
@@ -18,6 +18,7 @@ type ProjectDetailProps = {
   credits: CreditsType[];
   content: ContentBlockType[];
   details: { [key: string]: string };
+  externalUrl: string;
   intro: string;
   relatedProjectsTitle: string;
   relatedProjects: RelatedProject[];
@@ -28,6 +29,7 @@ const ProjectDetail = ({
   credits,
   content,
   details,
+  externalUrl,
   intro,
   relatedProjects,
   relatedProjectsTitle,
@@ -49,7 +51,7 @@ const ProjectDetail = ({
         <ContentBlock {...block} key={block.id} />
       ))}
 
-      <Credits credits={credits} details={details} />
+      <Credits credits={credits} externalUrl={externalUrl} details={details} />
 
       {relatedProjects && relatedProjects.length > 0 && (
         <RelatedProjectSlider

--- a/src/pages/projects/[slug]/index.tsx
+++ b/src/pages/projects/[slug]/index.tsx
@@ -21,6 +21,7 @@ type ProjectProps = {
   content: ContentBlockType[];
   credits?: CreditsType[];
   details: { [key: string]: string };
+  externalUrl: string;
   featuredImage: ImageData;
   id: string;
   intro: string;
@@ -32,8 +33,9 @@ type ProjectProps = {
 
 const Project = ({
   content,
-  details,
   credits,
+  details,
+  externalUrl,
   featuredImage,
   intro,
   opengraph: { description: ogDescription, image, title: ogTitle },
@@ -55,6 +57,7 @@ const Project = ({
         content={content}
         details={details}
         credits={credits}
+        externalUrl={externalUrl}
         intro={intro}
         relatedProjects={relatedProjects}
         relatedProjectsTitle={relatedProjectsTitle}


### PR DESCRIPTION
This MR adds support to project pages for linking to external project live/archive pages. This is particularly useful for web projects, where we have not historically been able to link directly to them before.

This ties in to separate work being done to publish archive versions of lost digital projects, via *.archive.random.studio.

**Steps to test**
1.  Visit the Chloe project
2. Below the credits block, there is a new 'View website' link that links to an archived copy of the A Season in Hope campaign site