### PR TITLE
Fix jumping carousel image height

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint \"src/**/*.{js,jsx,json}\" --fix --cache --cache-location ~/.eslintcache/eslintcache"
   },
   "dependencies": {
+    "classnames": "^2.3.2",
     "graphql-request": "5.1.0",
     "hls.js": "1.3.3",
     "lodash-es": "4.17.21",

--- a/src/components/Carousel/Carousel.module.css
+++ b/src/components/Carousel/Carousel.module.css
@@ -4,20 +4,22 @@
 
 .slides {
   position: relative;
-}
-
-.hasMultiple {
   cursor: e-resize;
 }
 
 .image {
   width: 100%;
   height: 100%;
+  overflow: hidden;
   opacity: 0;
 
-  &:not(:first-of-type) {
-    position: absolute;
+  &:not(:first-of-type),
+  &:not(:first-of-type) > div {
+    position: absolute !important;
     bottom: 0;
+    top: 0;
+    left: 0;
+    right: 0;
   }
 
   & video {
@@ -32,6 +34,7 @@
     transition: opacity 1.2s;
     opacity: 1;
   }
+
 }
 
 .caption {

--- a/src/components/Carousel/Carousel.module.css
+++ b/src/components/Carousel/Carousel.module.css
@@ -7,24 +7,20 @@
   cursor: e-resize;
 }
 
-.image {
+.slide {
   width: 100%;
   height: 100%;
   overflow: hidden;
   opacity: 0;
 
-  &:not(:first-of-type),
-  &:not(:first-of-type) > div {
-    position: absolute !important;
-    bottom: 0;
+  &:not(:first-child) {
+    position: absolute;
     top: 0;
     left: 0;
     right: 0;
+    bottom: 0;
   }
 
-  & video {
-    width: 100%;
-  }
 
   &[data-visible="false"] {
     pointer-events: none;

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -26,19 +26,21 @@ const Carousel = ({ caption, className, slides, sizes, width }: CarouselProps) =
       <div className={styles.slides}>
         {slides.map(({ id, video, image }, index) => (
           <div
-            className={styles.image}
+            className={styles.slide}
             data-visible={index === currentIndex}
             key={id}
             onClick={handleNext}
           >
             {video && (
-              <VideoWithControls video={video} />
+              <VideoWithControls className={styles.video} video={video} />
             )}
 
             {image && (
               <Image
+                className={styles.image}
                 data={image.imageData}
                 sizes={sizes}
+                layout={index === 0 ? 'responsive' : 'fill'}
               />
             )}
           </div>

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -29,22 +29,18 @@ const Carousel = ({ caption, className, slides, sizes, width }: CarouselProps) =
             className={styles.image}
             data-visible={index === currentIndex}
             key={id}
+            onClick={handleNext}
           >
-            <div
-              className={slides.length > 1 && styles.hasMultiple}
-              onClick={handleNext}
-            >
-              {video && (
-                <VideoWithControls video={video} />
-              )}
+            {video && (
+              <VideoWithControls video={video} />
+            )}
 
-              {image && (
-                <Image
-                  data={image.imageData}
-                  sizes={sizes}
-                />
-              )}
-            </div>
+            {image && (
+              <Image
+                data={image.imageData}
+                sizes={sizes}
+              />
+            )}
           </div>
         ))}
       </div>

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import Navigation from '../Navigation/Navigation';
 import Footer from '../Footer/Footer';
 import styles from './Layout.module.css';
 import useSunset from '../../utils/hooks/useSunset';
-import classNames from '../../utils/classNames';
 import AfterDarkContext from './AfterDarkContext';
 
 const Layout = ({
@@ -21,12 +21,11 @@ const Layout = ({
     [styles.newLayout]: isNewDesign,
     [styles.oldLayout]: !isNewDesign,
     [styles.isAfterDark]: isDarkStyleActive,
-    isAfterDark: isDarkStyleActive,
   });
 
   return (
     <AfterDarkContext.Provider value={isAfterDark}>
-      <div className={layoutClasses}>
+      <div className={`${layoutClasses} ${isDarkStyleActive && 'isAfterDark'}`}>
         <a className="screen-reader-only" href="#main-content" id="skip-nav">
           {'Skip Navigation'}
         </a>

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -17,16 +17,16 @@ const Layout = ({
 
   const isDarkStyleActive = isAfterDark && isNewDesign;
 
-  const layoutClasses = classNames({
-    className,
+  const layoutClasses = classNames(className, {
     [styles.newLayout]: isNewDesign,
     [styles.oldLayout]: !isNewDesign,
     [styles.isAfterDark]: isDarkStyleActive,
+    isAfterDark: isDarkStyleActive,
   });
 
   return (
     <AfterDarkContext.Provider value={isAfterDark}>
-      <div className={`${layoutClasses} ${isDarkStyleActive && 'isAfterDark'}`}>
+      <div className={layoutClasses}>
         <a className="screen-reader-only" href="#main-content" id="skip-nav">
           {'Skip Navigation'}
         </a>

--- a/src/components/ProjectList/Filters/Filters.js
+++ b/src/components/ProjectList/Filters/Filters.js
@@ -1,8 +1,8 @@
 import { useRouter } from 'next/router';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import styles from './Filters.module.scss';
-import classNames from '../../../utils/classNames';
 import { projectPropType } from '../../../propTypes';
 import { ORDERED_TAGS } from '../../../CONSTANTS';
 

--- a/src/components/SustainabilitySection/SustainabilitySection.js
+++ b/src/components/SustainabilitySection/SustainabilitySection.js
@@ -1,17 +1,15 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import styles from './SustainabilitySection.module.css';
 import Image from '../Image/Image';
-import classNames from '../../utils/classNames';
 import { externalLinkRenderer } from '../../utils/externalLinkRenderer';
 
 const SustainabilitySection = ({ section }) => {
   const { image, text, title, textFirst, color } = section;
 
-  const sectionClasses = classNames({
-    [styles.section]: true,
+  const sectionClasses = classNames(styles.section, styles[color], {
     [styles.reverse]: textFirst,
-    [styles[color]]: true,
   });
 
   return (

--- a/src/utils/classNames.js
+++ b/src/utils/classNames.js
@@ -1,6 +1,0 @@
-const classNames = object =>
-  Object.entries(object)
-    .map(([className, conditional]) => (conditional ? className : ''))
-    .join(' ');
-
-export default classNames;


### PR DESCRIPTION
When carousel images' aspect ratios do not match, the carousel height will vary. This can result in the images overlapping the number/pagination indicator, or a varying margin height above the pagination.

As agreed, the first slide should dictate the slide of the carousel. This MR ensures successive slides only fill the same aspect ratio space as the first slide.

**Steps to test**
1.  Visit the Jaquemus project page
2. Image carousel slides should all match each other