### PR TITLE
Add playsinline to video component

### DIFF
--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -59,6 +59,7 @@ const Video = ({
         subsCapsButton: false, // safari
       },
       loop: isLooping,
+      playsinline: true
     });
 
     setPlayer(videoJsPlayer);


### PR DESCRIPTION
## Testing
- Open the preview link on Safari mac, and mobile browsers
- The videos should autoplay
Note: Make sure your battery is not low, otherwise this will not work.