### PR TITLE
fix black line around video on safari

### DIFF
--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -67,6 +67,7 @@ When change is live everywhere, newLayout can become :root and other code can be
   --blue: lab(49.827 31.172 -78.866);
   --dark-grey: lab(43.19 0 0);
   --light-grey: lab(94.10 0 0);
+  --background-color: var(--off-white);
 
   & .newLayout {
     background-color: var(--white);

--- a/src/components/Video/Video.module.scss
+++ b/src/components/Video/Video.module.scss
@@ -14,7 +14,7 @@
     width: 100%;
     height: 100% !important;
     padding: 0 !important;
-    background-color: white;
+    background-color: var(--background-color);
 
     video {
       position: relative;

--- a/src/components/Video/Video.module.scss
+++ b/src/components/Video/Video.module.scss
@@ -17,6 +17,7 @@
 
     video {
       position: relative;
+      background-color: white;
     }
 
     // Custom video player styling

--- a/src/components/Video/Video.module.scss
+++ b/src/components/Video/Video.module.scss
@@ -14,10 +14,10 @@
     width: 100%;
     height: 100% !important;
     padding: 0 !important;
+    background-color: white;
 
     video {
       position: relative;
-      background-color: white;
     }
 
     // Custom video player styling

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -115,7 +115,7 @@ const Video = ({
           style={aspectRatioStyle}
         />
 
-        <div ref={videoContainerRef} />
+        <div ref={videoContainerRef} style={aspectRatioStyle} />
       </div>
     </LazyLoad>
   );

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -59,7 +59,7 @@ const Video = ({
         subsCapsButton: false, // safari
       },
       loop: isLooping,
-      playsinline: true
+      playsinline: true,
     });
 
     setPlayer(videoJsPlayer);
@@ -102,7 +102,7 @@ const Video = ({
   }
 
   const hasLoadedClassName = hasLoaded ? styles.isLoaded : '';
-  const aspectRatioStyle = { aspectRatio: video.width / video.height };
+  const aspectRatioStyle = { aspectRatio: `${video.width} / ${video.height}` };
 
   return (
     <LazyLoad onIntersect={handleLoadVideo}>
@@ -115,7 +115,7 @@ const Video = ({
           style={aspectRatioStyle}
         />
 
-        <div ref={videoContainerRef} style={aspectRatioStyle} />
+        <div ref={videoContainerRef} />
       </div>
     </LazyLoad>
   );


### PR DESCRIPTION
- Remove aspect ratio from the video wrapper (video has inherit size)
- Keep the aspect ratio style on the image placeholder
- Add a white background on the video-js wrapper, seems to help

## Testing
- On Safari, videos don't have black borders on any side