### PR TITLE
Add example custom button

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,8 @@
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "vscode.typescript-language-features"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   }
 }

--- a/src/components/Video/Video.module.scss
+++ b/src/components/Video/Video.module.scss
@@ -29,6 +29,21 @@
       height: 3.5em;
       background-color: none;
       background: linear-gradient(transparent, rgb(0 0 0 / 0.35));
+
+      // Custom Controls
+      .playerPlayPause {
+        --content: "Pause";
+
+        &:global(.vjs-paused) {
+          --content: "Play";
+        }
+
+        :global(.vjs-icon-placeholder) {
+          &::before {
+            content: var(--content);
+          }
+        }
+      }
     }
 
     :global(.vjs-control):focus {

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -7,12 +7,12 @@ import { VideoData } from '../../types/types';
 import LazyLoad from '../LazyLoad/LazyLoad';
 import useSharedUnmutedVideoState from './useSharedUnmutedVideoState';
 import 'video.js/dist/video-js.css';
+import { addCustomComponentToVideo } from './utils';
 
 // This is available but not typed in video.js
 type VideoJsComponent = Component & {
   handleClick: () => void;
 };
-
 export type VideoProps = {
   hasControls?: boolean;
   isAutoplaying?: boolean;
@@ -34,6 +34,22 @@ const Video = ({
   const [isMuted, toggleIsMuted] = useSharedUnmutedVideoState(
     video?.hls ?? 'unknown',
   );
+
+  const addCustomControls = (videoJsPlayer: Player) => {
+    const playPauseButton = addCustomComponentToVideo(
+      videoJsPlayer,
+      'PlayToggle',
+      {
+        className: styles.playerPlayPause,
+        clickHandler: () => {
+          videojs.log('custom button clicked');
+        },
+      },
+    );
+
+    // eslint-disable-next-line no-console
+    console.log(playPauseButton);
+  };
 
   const handleLoadVideo = useCallback(() => {
     if (!video) {
@@ -62,6 +78,7 @@ const Video = ({
       playsinline: true,
     });
 
+    addCustomControls(videoJsPlayer);
     setPlayer(videoJsPlayer);
   }, [hasControls, isAutoplaying, isLooping, video]);
 

--- a/src/components/Video/utils.ts
+++ b/src/components/Video/utils.ts
@@ -1,0 +1,30 @@
+import videojs from 'video.js';
+import Player from 'video.js/dist/types/player.d';
+
+type ComponentTypes =
+  | 'Button' // https://docs.videojs.com/playtoggle
+  | 'PlayToggle' // https://docs.videojs.com/button
+  | 'ProgressControl'; // https://docs.videojs.com/progresscontrol
+
+type OptionValuesTypes = string | (() => void);
+
+const addCustomComponentToVideo = (
+  currentPlayer: Player,
+  component: ComponentTypes,
+  options: {
+    [key: string]: OptionValuesTypes;
+  },
+) => {
+  const ComponentConstructor = videojs.getComponent(component);
+
+  // @ts-expect-error Incomplete typings on the videojs library
+  const customComponent = new ComponentConstructor(currentPlayer, options);
+
+  currentPlayer.getChild('ControlBar').addChild(customComponent);
+
+  return customComponent;
+};
+
+// New functions will be added
+// eslint-disable-next-line import/prefer-default-export
+export { addCustomComponentToVideo };


### PR DESCRIPTION
- Add new helper function to add different types of control Component to the player
- Add an example "Play/Pause" button, and associated stylings

Consider this boilerplate code that we can continue working on, hence I'm targeting `video-focus-mode`.