### PR TITLE
adjust autoplay

### DIFF
--- a/src/components/HomeVideo/HomeVideo.module.css
+++ b/src/components/HomeVideo/HomeVideo.module.css
@@ -8,14 +8,12 @@
 
 .videoWrapper {
   width: 100%;
+  max-height: 100vh;
+  min-height: 60vh;
 
   & video {
     width: 100%;
-    height: auto;
-    min-height: 60vh;
-    min-height: 60svh;
-    max-height: 100vh;
-    max-height: 100svh;
+    height: 100%;
   }
 }
 

--- a/src/components/LazyLoad/LazyLoad.tsx
+++ b/src/components/LazyLoad/LazyLoad.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 
 type LazyLoadProps = {
-  children: React.ReactNode;
+  children: JSX.Element;
   onIntersect?: () => void;
 };
 

--- a/src/components/Video/Controls/Controls.tsx
+++ b/src/components/Video/Controls/Controls.tsx
@@ -36,7 +36,11 @@ const Controls = ({
 
   useEffect(() => {
     if (isPlaying) {
-      videoRef.current?.play();
+      videoRef.current
+        .play()
+        .catch(e =>
+          console.warn('Unable to autoplay without user interaction', e),
+        );
     } else {
       videoRef.current?.pause();
     }

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -52,14 +52,15 @@ const Video = forwardRef<HTMLVideoElement, VideoProps>(
 
     const handleVideoReady = useCallback(() => {
       setHasLoaded(true);
-    }, []);
+      onReady();
+    }, [onReady]);
 
     const aspectRatioStyle = { aspectRatio: `${width} / ${height}` };
 
     useHlsVideo({
       isAutoplaying,
       isMounted,
-      onReady,
+      onReady: handleVideoReady,
       videoRef,
       src: hls,
     });
@@ -94,10 +95,9 @@ const Video = forwardRef<HTMLVideoElement, VideoProps>(
                 loop={isLooping}
                 muted
                 onClick={handleClick}
-                onPlaying={handleVideoReady}
                 playsInline
                 ref={videoRef}
-                src=""
+                src={hls}
                 style={aspectRatioStyle}
               />
 

--- a/src/pages/video/[id]/index.tsx
+++ b/src/pages/video/[id]/index.tsx
@@ -60,7 +60,11 @@ const VideoFocusModePage = ({ video }: VideoFocusModePageProps) => {
 
   const handleClick = useCallback(() => {
     if (videoRef.current?.paused) {
-      videoRef.current?.play();
+      videoRef.current
+        .play()
+        .catch(e =>
+          console.warn('Unable to autoplay without user interaction', e),
+        );
     } else {
       videoRef.current?.pause();
     }


### PR DESCRIPTION
- Wait for 'manifest' to be ready before trying to play the hls video
- Catch `play()` errors
- Other small adjustments

## Testing
- The videos should be playing properly on all browsers. 
Please note, this doesn't mean that they ALWAYS autoplay. But if they fail to autoplay, pressing the play button should play them. Nothing should break in that case.