### PR TITLE
Download link

### DIFF
--- a/src/components/Video/Controls/Controls.tsx
+++ b/src/components/Video/Controls/Controls.tsx
@@ -104,12 +104,7 @@ const Controls = ({
         {'Share'}
       </button>
 
-      <a
-        download
-        href={videoRef.current?.dataset.downloadSrc}
-        rel="noreferrer"
-        target="_blank"
-      >
+      <a download href={videoRef.current?.dataset.downloadSrc}>
         {'Download'}
       </a>
     </div>

--- a/src/components/Video/Controls/Controls.tsx
+++ b/src/components/Video/Controls/Controls.tsx
@@ -104,7 +104,12 @@ const Controls = ({
         {'Share'}
       </button>
 
-      <a download href={videoRef.current?.dataset.downloadSrc}>
+      <a
+        download
+        href={videoRef.current?.dataset.downloadSrc}
+        rel="noreferrer"
+        target="_blank"
+      >
         {'Download'}
       </a>
     </div>

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -33,7 +33,7 @@ const Video = forwardRef<HTMLVideoElement, VideoProps>(
       onClick,
       onReady,
       onMount,
-      video: { baseUrl, blur, guid, height, hls, width },
+      video: { downloadUrl, blur, guid, height, hls, width },
     },
     ref,
   ) => {
@@ -90,7 +90,7 @@ const Video = forwardRef<HTMLVideoElement, VideoProps>(
                 autoPlay
                 className={styles.video}
                 controls={false}
-                data-download-src={`${baseUrl}/original`}
+                data-download-src={downloadUrl}
                 id={guid}
                 loop={isLooping}
                 muted

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -4,6 +4,7 @@ export interface VideoData {
     thumbnail: string;
     dominantColor: string;
   };
+  downloadUrl: string;
   fallback: string;
   guid: string;
   height;

--- a/src/utils/videoUtils.ts
+++ b/src/utils/videoUtils.ts
@@ -34,8 +34,9 @@ export const formatVideoData = async (details): Promise<VideoData> => {
     fallback: thumbnailUrl,
     guid,
     height,
-    hls: `${baseUrl}/play_720p.mp4`,
+    hls: `${baseUrl}/playlist.m3u8`,
     width,
+    downloadUrl: `${baseUrl}/play_720p.mp4`,
   };
 
   if (typeof window === 'undefined') {

--- a/src/utils/videoUtils.ts
+++ b/src/utils/videoUtils.ts
@@ -34,7 +34,7 @@ export const formatVideoData = async (details): Promise<VideoData> => {
     fallback: thumbnailUrl,
     guid,
     height,
-    hls: `${baseUrl}/playlist.m3u8`,
+    hls: `${baseUrl}/play_720p.mp4`,
     width,
   };
 


### PR DESCRIPTION
- Use the fallback `720p mp4` file for download. We can't serve to the users a ProRes file to be downloaded (example jacquemus video). The file is too big to be played on a browser, and it lags. And also, safari can't resolve the filename.

- Unfortunately, there's no easy way to "force" a download as soon as you click on a button. It's a browser thing that tries to preview the files first.