### PR TITLE
Frictionless video opening

### DIFF
--- a/src/components/ProjectDetail/ContentBlock/ContentBlock.tsx
+++ b/src/components/ProjectDetail/ContentBlock/ContentBlock.tsx
@@ -43,6 +43,8 @@ const ContentBlock = ({
       url.pathname = `/video/${videoEl.id}/`;
       url.searchParams.set('projectId', slug as string);
       url.searchParams.set('time', time.toString());
+      url.searchParams.set('isOpenedFromProject', 'true');
+      url.searchParams.set('isMuted', videoEl.muted ? 'true' : 'false');
       router.push(url.href);
     },
     [router],

--- a/src/components/Video/Controls/Progress/useMouseHoverPosition.ts
+++ b/src/components/Video/Controls/Progress/useMouseHoverPosition.ts
@@ -2,7 +2,7 @@ import {
   MouseEvent,
   MutableRefObject,
   useCallback,
-  useLayoutEffect,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -52,7 +52,7 @@ const useMouseHoverPosition = (
     [elementBoundingRectRef, isHovering],
   );
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!isActive || !ref || !ref.current) {
       return undefined;
     }

--- a/src/components/Video/Controls/useSharedUnmutedVideoState.tsx
+++ b/src/components/Video/Controls/useSharedUnmutedVideoState.tsx
@@ -5,15 +5,15 @@ interface Store {
   activeSrc: string | null;
 }
 
-const useStore = create<Store>(() => ({
+export const useMutedStore = create<Store>(() => ({
   activeSrc: null,
 }));
 
 const useSharedUnmutedVideoState = (src: string) => {
-  const isMuted = useStore(state => state.activeSrc !== src);
+  const isMuted = useMutedStore(state => state.activeSrc !== src);
 
   const toggleIsMuted = useCallback(() => {
-    useStore.setState({
+    useMutedStore.setState({
       activeSrc: isMuted ? src : null,
     });
   }, [isMuted, src]);

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -17,6 +17,7 @@ export type VideoProps = {
   hasControls?: boolean;
   isAutoplaying?: boolean;
   isLooping?: boolean;
+  isMuted?: boolean;
   onClick?: (video: HTMLVideoElement) => void;
   onMount?: () => void;
   onReady?: () => void;
@@ -28,8 +29,9 @@ const Video = forwardRef<HTMLVideoElement, VideoProps>(
     {
       className,
       hasControls,
-      isAutoplaying = false,
+      isAutoplaying = true,
       isLooping,
+      isMuted = true,
       onClick,
       onReady,
       onMount,
@@ -93,7 +95,7 @@ const Video = forwardRef<HTMLVideoElement, VideoProps>(
                 data-download-src={downloadUrl}
                 id={guid}
                 loop={isLooping}
-                muted
+                muted={isMuted}
                 onClick={handleClick}
                 playsInline
                 ref={videoRef}
@@ -119,6 +121,7 @@ Video.defaultProps = {
   hasControls: false,
   isAutoplaying: true,
   isLooping: true,
+  isMuted: true,
   onClick: () => null,
   onMount: () => null,
   onReady: () => null,

--- a/src/pages/projects/[slug]/index.tsx
+++ b/src/pages/projects/[slug]/index.tsx
@@ -17,6 +17,7 @@ import {
   OpenGraph,
   ProjectSummary,
 } from '../../../types/types';
+import useScrollRestoration from './useScrollRestoration';
 
 type ProjectProps = {
   content: ContentBlockType[];
@@ -41,6 +42,8 @@ const Project = ({
   relatedProjectsTitle,
   title,
 }: ProjectProps) => {
+  useScrollRestoration();
+
   return (
     <Layout className={styles.layout} hasFooter={false}>
       <Head

--- a/src/pages/projects/[slug]/useScrollRestoration.ts
+++ b/src/pages/projects/[slug]/useScrollRestoration.ts
@@ -3,17 +3,22 @@ import { useEffect } from 'react';
 
 const useScrollRestoration = () => {
   const router = useRouter();
-  const { history } = window;
 
   // set scroll restoration to manual
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const { history } = window;
+
     if (
       'scrollRestoration' in history &&
       history.scrollRestoration !== 'manual'
     ) {
       history.scrollRestoration = 'manual';
     }
-  }, [history]);
+  }, []);
 
   // handle and store scroll position
   useEffect(() => {

--- a/src/pages/projects/[slug]/useScrollRestoration.ts
+++ b/src/pages/projects/[slug]/useScrollRestoration.ts
@@ -1,0 +1,44 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+const useScrollRestoration = () => {
+  const router = useRouter();
+  const { history } = window;
+
+  // set scroll restoration to manual
+  useEffect(() => {
+    if (
+      'scrollRestoration' in history &&
+      history.scrollRestoration !== 'manual'
+    ) {
+      history.scrollRestoration = 'manual';
+    }
+  }, [history]);
+
+  // handle and store scroll position
+  useEffect(() => {
+    const handleRouteChange = (nextPath: string) => {
+      const isOpeningVideo = nextPath.startsWith('/video');
+
+      if (isOpeningVideo) {
+        sessionStorage.setItem('scrollPosition', window.scrollY.toString());
+      }
+    };
+
+    router.events.on('routeChangeStart', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+    };
+  }, [router.events]);
+
+  // restore scroll position
+  useEffect(() => {
+    if ('scrollPosition' in sessionStorage) {
+      window.scrollTo(0, Number(sessionStorage.getItem('scrollPosition')));
+      sessionStorage.removeItem('scrollPosition');
+    }
+  }, []);
+};
+
+export default useScrollRestoration;

--- a/src/pages/video/[id]/index.tsx
+++ b/src/pages/video/[id]/index.tsx
@@ -150,7 +150,7 @@ const VideoFocusModePage = ({ video }: VideoFocusModePageProps) => {
             hasControls={false}
             isAutoplaying
             isLooping
-            isMuted={isMuted === 'true'}
+            isMuted={isMuted}
             onClick={handleClick}
             onReady={handleReady}
             ref={videoRef}

--- a/src/pages/video/[id]/index.tsx
+++ b/src/pages/video/[id]/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../utils/videoUtils';
 import { getVideosList } from '../../../../netlify/functions/getVideosList';
 import { getVideoDetailsByIdOnServer } from '../../../server/methods';
+import { useMutedStore } from '../../../components/Video/Controls/useSharedUnmutedVideoState';
 
 // Fetcher function that fetches data from getVideoData netlify function
 const fetcher = async (videoRef: string, video: VideoData) => {
@@ -56,7 +57,7 @@ const VideoFocusModePage = ({ video }: VideoFocusModePageProps) => {
   const time = params.get('time');
   const projectId = params.get('time');
   const isOpenedFromProject = params.get('isOpenedFromProject');
-  const isMuted = params.get('isMuted');
+  const isMuted = params.get('isMuted') === 'true';
 
   const [isReady, setIsReady] = useState(false);
 
@@ -78,8 +79,15 @@ const VideoFocusModePage = ({ video }: VideoFocusModePageProps) => {
     }
 
     setIsReady(true);
+
+    if (!isMuted) {
+      useMutedStore.setState({
+        activeSrc: videoRef.current.src,
+      });
+    }
+
     videoRef.current.currentTime = Number(time) || 0;
-  }, [time]);
+  }, [isMuted, time]);
 
   const closeJsx = useMemo(() => {
     if (isOpenedFromProject) {

--- a/src/pages/video/[id]/index.tsx
+++ b/src/pages/video/[id]/index.tsx
@@ -47,8 +47,6 @@ const VideoFocusModePage = ({ video }: VideoFocusModePageProps) => {
   const router = useRouter();
 
   const { id } = router.query;
-  const searchParams = useSearchParams();
-  const projectId = searchParams.get('projectId');
 
   const { data, error } = useSwr(id, () => fetcher(id as string, video), {
     fallbackData: video,
@@ -56,6 +54,9 @@ const VideoFocusModePage = ({ video }: VideoFocusModePageProps) => {
 
   const params = useSearchParams();
   const time = params.get('time');
+  const projectId = params.get('time');
+  const isOpenedFromProject = params.get('isOpenedFromProject');
+  const isMuted = params.get('isMuted');
 
   const [isReady, setIsReady] = useState(false);
 
@@ -81,19 +82,18 @@ const VideoFocusModePage = ({ video }: VideoFocusModePageProps) => {
   }, [time]);
 
   const closeJsx = useMemo(() => {
-    if (projectId) {
+    if (isOpenedFromProject) {
       const handleBack = (event: MouseEvent<HTMLAnchorElement>) => {
-        router.back();
-
         event.preventDefault();
+        router.back();
 
         return false;
       };
 
       return (
-        <a href={`/projects/${projectId}`} onClick={handleBack}>
+        <Link href={`/projects/${projectId}`} onClick={handleBack}>
           {'Back'}
-        </a>
+        </Link>
       );
     }
 
@@ -102,7 +102,7 @@ const VideoFocusModePage = ({ video }: VideoFocusModePageProps) => {
     }
 
     return <Link href="/">{'Close'}</Link>;
-  }, [router, projectId]);
+  }, [isOpenedFromProject, router, projectId]);
 
   const hasInvertedColors = useMemo(() => {
     if (!data || !data.blur) {
@@ -142,6 +142,7 @@ const VideoFocusModePage = ({ video }: VideoFocusModePageProps) => {
             hasControls={false}
             isAutoplaying
             isLooping
+            isMuted={isMuted === 'true'}
             onClick={handleClick}
             onReady={handleReady}
             ref={videoRef}

--- a/src/utils/hooks/useSunset.ts
+++ b/src/utils/hooks/useSunset.ts
@@ -34,15 +34,19 @@ const useSunset = () => {
     const now = new Date(Date.now());
     let timer: number;
 
-    getSunriseSunsetTimes().then(([sunrise, sunset]) => {
-      const isNight = sunset > now;
-      setIsAfterDark(isNight);
+    getSunriseSunsetTimes()
+      .then(([sunrise, sunset]) => {
+        const isNight = sunset > now;
+        setIsAfterDark(isNight);
 
-      timer = window.setTimeout(
-        () => setIsAfterDark(value => !value),
-        (isNight ? sunrise : sunset).getTime() - now.getTime(),
-      );
-    });
+        timer = window.setTimeout(
+          () => setIsAfterDark(value => !value),
+          (isNight ? sunrise : sunset).getTime() - now.getTime(),
+        );
+      })
+      .catch(() => {
+        console.warn('Could not fetch sunrise/sunset times');
+      });
 
     return () => {
       clearTimeout(timer);


### PR DESCRIPTION
Fixes two small defects in how video focus mode opens from the project page:

1. Persist mute state – if video is muted, stay muted. If video is unmuted, stay unmuted
2. Scroll restoration – going back to project page from a video will persist the scroll position

It's important to note scroll restoration doesn't work elsewhere on the site, and hasn't for a long time. This needs some attention, wasn't able to solve it this time. Opening the video is the most noticeable case, however.

**Steps to test**
1.  From a project, open a video and test that above statements are true