### PR TITLE
Larger back button click area

### DIFF
--- a/src/pages/video/[id]/index.module.css
+++ b/src/pages/video/[id]/index.module.css
@@ -36,6 +36,31 @@
   a {
     color: rgb(var(--text-color));
     text-decoration: none;
+
+    &:hover {
+      animation: cycle-opacity 1s ease-in-out infinite;
+    }
+
+    &::after {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 50%;
+      content: '';
+    }
+  }
+}
+
+@keyframes cycle-opacity {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
   }
 }
 
@@ -45,11 +70,9 @@
   place-items: center;
   width: 100%;
   grid-row: 2 / 3;
-  height: 100%;
 
   .frame {
     width: 100%;
-    height: 100%;
     /* Ignore aspect ratio on frame, handle sizing via flex */
     aspect-ratio: unset !important;
   }
@@ -67,8 +90,18 @@
 
   video {
     width: 100%;
-    height: 100%;
     object-fit: contain;
+  }
+
+  .isVerticalVideo & {
+    height: 100%;
+    width: auto;
+
+    .frame,
+    video {
+      height: 100%;
+      width: auto;
+    }
   }
 }
 

--- a/src/pages/video/[id]/index.tsx
+++ b/src/pages/video/[id]/index.tsx
@@ -127,6 +127,7 @@ const VideoFocusModePage = ({ video }: VideoFocusModePageProps) => {
 
   const gridClassNames = classNames(styles.grid, {
     [styles.hasInvertedColors]: hasInvertedColors,
+    [styles.isVerticalVideo]: data?.height > data?.width,
   });
 
   return (


### PR DESCRIPTION
The back button on the video focus page is not always 100% obvious at first glance, with a small click area.

This MR:

- Makes the whole top 50% of the page background clickable to go back.
- Gives the back button a pulsing opacity animation while hovered, to indicate what behaviour will be triggered when the user clicks


**Steps to test**
1.  First of all, verify that above statements are true
2. Check that videos still display correctly for: one vertical, one landscape orientation video on desktop; one vertical, one landscape on mobile