### PR TITLE
Ensure video has maximum constraints

### DIFF
--- a/src/components/Video/Controls/Controls.tsx
+++ b/src/components/Video/Controls/Controls.tsx
@@ -16,7 +16,7 @@ const Controls = ({
   className = undefined,
   isAutoplaying = false,
   hasExtendedControls = false,
-  onClick = null,
+  onClick = () => null,
   videoRef,
 }: ControlsProps) => {
   /*

--- a/src/pages/video/[id]/index.module.css
+++ b/src/pages/video/[id]/index.module.css
@@ -77,6 +77,12 @@
     aspect-ratio: unset !important;
   }
 
+  .frame,
+  video {
+    max-height: 100%;
+    max-width: 100%;
+  }
+
   .brokenVideo {
     width: 100%;
     aspect-ratio: 16/9;


### PR DESCRIPTION
Video should never overflow the space allocated for it by CSS grid. Ensure it and its frame have max-width/max-height set.

**Steps to test**
1.  Open both a landscape and portrait video (there's a portrait video on Jacquemus)
2. Test changing window, verify video is always contained _within_ its frame