### PR TITLE
Header should not capture all pointer events

### DIFF
--- a/src/components/Logo/Logo.module.css
+++ b/src/components/Logo/Logo.module.css
@@ -2,7 +2,6 @@
   @mixin logo;
   font-size: var(--font-logo-small);
   margin: 0;
-  pointer-events: all;
   z-index: 1;
   text-align: left;
 
@@ -16,6 +15,7 @@
 
   & a {
     display: inline-block;
+    pointer-events: auto;
     text-decoration: none;
   }
 

--- a/src/components/Navigation/Navigation.module.css
+++ b/src/components/Navigation/Navigation.module.css
@@ -6,7 +6,7 @@
   top: 40px;
   left: 20px;
   right: 20px;
-  pointer-events: all;
+  pointer-events: none;
   z-index: 5;
   mix-blend-mode: difference;
 
@@ -32,6 +32,7 @@
   column-gap: 32px;
   padding: 0;
   margin: 0;
+  pointer-events: auto;
 
   @media (--desktop) {
     @mixin body-2;

--- a/src/components/Video/Controls/Controls.tsx
+++ b/src/components/Video/Controls/Controls.tsx
@@ -16,7 +16,7 @@ const Controls = ({
   className = undefined,
   isAutoplaying = false,
   hasExtendedControls = false,
-  onClick = null,
+  onClick = () => null,
   videoRef,
 }: ControlsProps) => {
   /*


### PR DESCRIPTION
Currently the page header captures all pointer events, which can be confusing as it has a transparent background and spans the full width of the page.

This MR ensures the background does not capture pointer events, but each link does.

**Steps to test**
1.  Test on mobile and landscape
2.  Scroll and try to click through the background/empty space of the header, the click will hit the element below
3.  Click the logo/studio/project links, the links will work as expected